### PR TITLE
Do not delete messages on behalf of current chat

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -42,7 +42,7 @@ def with_default_filters(*filters: BaseFilter) -> BaseFilter:
 
 class IsMessageOnBehalfOfChat(MessageFilter):
     def filter(self, message: Message) -> bool:
-        return message.sender_chat is not None
+        return message.sender_chat is not None and message.sender_chat.id != message.chat.id
 
 
 class ContainsTelegramContact(MessageFilter):

--- a/tests/tests_filters/test_is_message_behalf_of_chat.py
+++ b/tests/tests_filters/test_is_message_behalf_of_chat.py
@@ -4,8 +4,17 @@ from filters import IsMessageOnBehalfOfChat
 
 
 @pytest.fixture
-def message(mock_message):
+def mock_chat():
+    class MockChat:
+        def __init__(self, chat_id: int) -> None:
+            self.id = chat_id
+
+    return lambda chat_id: MockChat(chat_id=chat_id)
+
+@pytest.fixture
+def message(mock_message, mock_chat):
     mock_message.sender_chat = None
+    mock_message.chat = mock_chat(chat_id=7)
     return mock_message
 
 
@@ -18,7 +27,13 @@ def test_false_if_no_sender_chat(do_filter, message):
     assert do_filter(message) is False
 
 
-def test_true_if_sender_chat(do_filter, message):
-    message.sender_chat = "very-suspicious-id"
+def test_false_if_sender_chat_same_as_current(do_filter, message, mock_chat):
+    message.sender_chat = message.chat
+
+    assert do_filter(message) is False
+
+
+def test_true_if_sender_chat(do_filter, message, mock_chat):
+    message.sender_chat = mock_chat(chat_id=55)
 
     assert do_filter(message) is True


### PR DESCRIPTION
Правка фильтра к issue [Не удалять сообщения от имени чата, в котором установлен бот ](https://github.com/f213/discussion-sentinel-bot/issues/17)

Добавил проверку на то, что sender_chat != chat